### PR TITLE
feat: add intermission and results flow

### DIFF
--- a/components/IntermissionElims.module.css
+++ b/components/IntermissionElims.module.css
@@ -1,0 +1,41 @@
+.container {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  justify-content: center;
+  height: 100%;
+  position: relative;
+}
+.video {
+  flex: 1;
+  width: 100%;
+  height: auto;
+}
+.listPanel {
+  flex: 0 0 40%;
+  padding: 1rem;
+  background: rgba(0,0,0,0.6);
+  color: white;
+}
+.heading {
+  margin-top: 0;
+}
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.banner {
+  position: absolute;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #c53030;
+  color: white;
+  padding: 0.5rem 1rem;
+  font-weight: bold;
+  border-radius: 4px;
+}
+.none {
+  font-style: italic;
+}

--- a/components/IntermissionElims.tsx
+++ b/components/IntermissionElims.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styles from './IntermissionElims.module.css';
+
+type Player = { id: number | string; username: string };
+
+interface IntermissionElimsProps {
+  videoUrl?: string | null;
+  eliminatedPlayers: Player[];
+  isEliminated: boolean;
+}
+
+export const IntermissionElims: React.FC<IntermissionElimsProps> = ({
+  videoUrl,
+  eliminatedPlayers,
+  isEliminated,
+}) => {
+  return (
+    <div className={styles.container}>
+      {videoUrl && <video src={videoUrl} autoPlay className={styles.video} />}
+      <aside className={styles.listPanel}>
+        <h2 className={styles.heading}>Eliminated</h2>
+        {eliminatedPlayers.length > 0 ? (
+          <ul className={styles.list}>
+            {eliminatedPlayers.map((p) => (
+              <li key={p.id}>{p.username}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className={styles.none}>No eliminations</p>
+        )}
+      </aside>
+      {isEliminated && <div className={styles.banner}>YOU ARE ELIMINATED</div>}
+    </div>
+  );
+};
+
+export default IntermissionElims;

--- a/components/IntermissionSurv.module.css
+++ b/components/IntermissionSurv.module.css
@@ -1,0 +1,47 @@
+.container {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  justify-content: center;
+  height: 100%;
+  position: relative;
+}
+.video {
+  flex: 1;
+  width: 100%;
+  height: auto;
+}
+.listPanel {
+  flex: 0 0 40%;
+  padding: 1rem;
+  background: rgba(0,0,0,0.6);
+  color: white;
+}
+.heading {
+  margin-top: 0;
+}
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.footer {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: rgba(0,0,0,0.7);
+  color: white;
+  box-sizing: border-box;
+}
+.leaderboard {
+  text-align: right;
+}
+.leaderboardList {
+  list-style: decimal;
+  margin: 0;
+  padding-left: 1.5rem;
+}

--- a/components/IntermissionSurv.tsx
+++ b/components/IntermissionSurv.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import styles from './IntermissionSurv.module.css';
+
+type Player = { id: number | string; username: string; score?: number; balance?: number };
+
+interface IntermissionSurvProps {
+  videoUrl?: string | null;
+  survivors: Player[];
+  prizePot: number;
+  everyoneSurvives?: boolean;
+}
+
+export const IntermissionSurv: React.FC<IntermissionSurvProps> = ({
+  videoUrl,
+  survivors,
+  prizePot,
+  everyoneSurvives,
+}) => {
+  const topPlayers = [...survivors]
+    .sort((a, b) => (b.score ?? b.balance ?? 0) - (a.score ?? a.balance ?? 0))
+    .slice(0, 5);
+
+  return (
+    <div className={styles.container}>
+      {videoUrl && <video src={videoUrl} autoPlay className={styles.video} />}
+      <aside className={styles.listPanel}>
+        <h2 className={styles.heading}>
+          {everyoneSurvives ? 'Everyone survives' : 'Survivors'}
+        </h2>
+        <ul className={styles.list}>
+          {survivors.map((p) => (
+            <li key={p.id}>{p.username}</li>
+          ))}
+        </ul>
+      </aside>
+      <footer className={styles.footer}>
+        <div>Prize Pot: ${prizePot.toLocaleString()}</div>
+        <div className={styles.leaderboard}>
+          <span>Top Players</span>
+          <ol className={styles.leaderboardList}>
+            {topPlayers.map((p) => (
+              <li key={p.id}>{p.username}</li>
+            ))}
+          </ol>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default IntermissionSurv;

--- a/components/RoundResultsModal.module.css
+++ b/components/RoundResultsModal.module.css
@@ -1,0 +1,39 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.modal {
+  background: white;
+  padding: 1rem 2rem;
+  border-radius: 8px;
+  max-width: 600px;
+  width: 100%;
+}
+.title {
+  margin-top: 0;
+  text-align: center;
+}
+.columns {
+  display: flex;
+  gap: 2rem;
+  justify-content: space-between;
+}
+.column {
+  flex: 1;
+}
+.column h3 {
+  margin-top: 0;
+}
+.column ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}

--- a/components/RoundResultsModal.tsx
+++ b/components/RoundResultsModal.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styles from './RoundResultsModal.module.css';
+
+type Player = { id: number | string; username: string };
+
+interface RoundResultsModalProps {
+  survivors: Player[];
+  eliminated: Player[];
+}
+
+export const RoundResultsModal: React.FC<RoundResultsModalProps> = ({
+  survivors,
+  eliminated,
+}) => {
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.modal}>
+        <h2 className={styles.title}>Round Results</h2>
+        <div className={styles.columns}>
+          <div className={styles.column}>
+            <h3>Survivors</h3>
+            <ul>
+              {survivors.map((p) => (
+                <li key={p.id}>{p.username}</li>
+              ))}
+            </ul>
+          </div>
+          <div className={styles.column}>
+            <h3>Eliminated</h3>
+            <ul>
+              {eliminated.map((p) => (
+                <li key={p.id}>{p.username}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RoundResultsModal;

--- a/helpers/useRoundFlow.tsx
+++ b/helpers/useRoundFlow.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+import type { Selectable } from 'kysely';
+import type { Games, Players } from './schema';
+
+export type RoundFlowPhase =
+  | 'Question'
+  | 'Intermission_Elims'
+  | 'Intermission_Surv'
+  | 'ResultsModal';
+
+type PlayerInfo = Pick<Selectable<Players>, 'id' | 'username' | 'status' | 'eliminatedRound'> & {
+  score?: number;
+  balance?: number;
+};
+
+export const useRoundFlow = (
+  game?: Selectable<Games> & { gameState?: string },
+  players: PlayerInfo[] = []
+) => {
+  return useMemo(() => {
+    if (!game) {
+      return {
+        phase: 'Question' as RoundFlowPhase,
+        eliminatedPlayers: [] as PlayerInfo[],
+        survivors: [] as PlayerInfo[],
+        everyoneSurvives: false,
+      };
+    }
+
+    const currentIndex = game.currentQuestionIndex ?? 0;
+    const eliminatedPlayers = players.filter(
+      (p) => p.status === 'eliminated' && p.eliminatedRound === currentIndex
+    );
+    const survivors = players.filter(
+      (p) => p.status === 'active' || p.status === 'redeemed'
+    );
+    const everyoneSurvives = eliminatedPlayers.length === 0;
+
+    let phase: RoundFlowPhase = 'Question';
+    const state = (game as any).gameState || (game as any).status;
+    switch (state) {
+      case 'elimination':
+        phase = everyoneSurvives ? 'Intermission_Surv' : 'Intermission_Elims';
+        break;
+      case 'survivors':
+        phase = 'Intermission_Surv';
+        break;
+      case 'round_results':
+        phase = 'ResultsModal';
+        break;
+      default:
+        phase = 'Question';
+    }
+
+    return { phase, eliminatedPlayers, survivors, everyoneSurvives };
+  }, [game, players]);
+};
+
+export default useRoundFlow;


### PR DESCRIPTION
## Summary
- add IntermissionElims component for elimination sequence with banner
- add IntermissionSurv component with survivor list, prize pot, and leaderboard
- display RoundResultsModal and manage flow via new useRoundFlow hook

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Type '(prev: string[]) => (string | number)[]' is not assignable to type '(prevState: string[]) => string[]'. ...)*

------
https://chatgpt.com/codex/tasks/task_e_689b412f83c08327adae8bcfdd51bc27