### PR TITLE
Add round flow hook and phase-based game rendering

### DIFF
--- a/hooks/useRoundFlow.ts
+++ b/hooks/useRoundFlow.ts
@@ -1,0 +1,104 @@
+import { useState, useEffect, useRef } from 'react';
+import { useWebSocket } from '../helpers/useWebSocket';
+
+export type Phase =
+  | 'Question'
+  | 'Lock'
+  | 'Intermission_Elims'
+  | 'Intermission_Surv'
+  | 'ResultsModal'
+  | 'Voting'
+  | 'RevealRedemption'
+  | 'WaitingNext';
+
+interface UseRoundFlowOptions {
+  gameCode: string;
+  eliminationVideoUrl?: string | null;
+  onUpdate?: () => void;
+}
+
+interface RoundFlowState {
+  phase: Phase;
+  votingRoundId: string | null;
+}
+
+/**
+ * Manages round flow transitions for players.
+ * Reacts to server websocket events and advances phases on timers.
+ */
+export function useRoundFlow({
+  gameCode,
+  eliminationVideoUrl,
+  onUpdate,
+}: UseRoundFlowOptions): RoundFlowState {
+  const [phase, setPhase] = useState<Phase>('Question');
+  const [votingRoundId, setVotingRoundId] = useState<string | null>(null);
+  const timers = useRef<number[]>([]);
+
+  const clearTimers = () => {
+    timers.current.forEach((t) => clearTimeout(t));
+    timers.current = [];
+  };
+
+  const schedule = (next: Phase, delay: number) => {
+    const id = window.setTimeout(() => {
+      setPhase(next);
+    }, delay);
+    timers.current.push(id);
+  };
+
+  const preloadVideo = (url: string) => {
+    if (!url) return;
+    const video = document.createElement('video');
+    video.src = url;
+    video.preload = 'auto';
+    // Loading begins immediately
+    video.load();
+  };
+
+  useWebSocket(gameCode, (message) => {
+    switch (message.type) {
+      case 'round_results': {
+        clearTimers();
+        setPhase('ResultsModal');
+        if (eliminationVideoUrl) {
+          preloadVideo(eliminationVideoUrl);
+        }
+        // Show results modal then elimination and survivor intermissions
+        schedule('Intermission_Elims', 4000);
+        schedule('Intermission_Surv', 8000);
+        schedule('WaitingNext', 12000);
+        onUpdate?.();
+        break;
+      }
+      case 'open_vote': {
+        clearTimers();
+        setPhase('Voting');
+        if (message.roundId) {
+          setVotingRoundId(String(message.roundId));
+        }
+        onUpdate?.();
+        break;
+      }
+      case 'vote_result': {
+        clearTimers();
+        setPhase('RevealRedemption');
+        schedule('WaitingNext', 4000);
+        onUpdate?.();
+        break;
+      }
+      case 'next_round': {
+        clearTimers();
+        setVotingRoundId(null);
+        setPhase('Question');
+        onUpdate?.();
+        break;
+      }
+    }
+  });
+
+  // Clear timers on unmount
+  useEffect(() => clearTimers, []);
+
+  return { phase, votingRoundId };
+}


### PR DESCRIPTION
## Summary
- add `useRoundFlow` hook managing round phases with timers and video preloading
- update game page to drive UI from round phases and show voting modal based on hook

## Testing
- `pnpm build` *(fails: Property '_id' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_689b412bc29c83278ee10684d92f818c